### PR TITLE
Update XML data to match schemas

### DIFF
--- a/src/test/resources/com/toshibacommerce/tlog/EAMTRANA_2.xml
+++ b/src/test/resources/com/toshibacommerce/tlog/EAMTRANA_2.xml
@@ -106,7 +106,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">1</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151416</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151416</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">8</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -249,7 +249,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">2</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151416</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151416</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">24</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -528,7 +528,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">3</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151416</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151416</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">11</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -722,7 +722,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">4</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151416</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151416</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">18</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -978,7 +978,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">5</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151416</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151416</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">22</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -1261,7 +1261,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">6</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151416</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151416</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">23</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -1577,7 +1577,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">7</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">15</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -1776,7 +1776,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">8</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">9</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -1881,7 +1881,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">9</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">22</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -2143,7 +2143,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">10</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">5</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -2208,7 +2208,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">11</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">16</TransactionType>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
         <Password xmlns="" xsi:type="xs:decimal">1</Password>
@@ -2224,7 +2224,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">12</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">3</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -2267,7 +2267,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">13</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">16</TransactionType>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
         <Password xmlns="" xsi:type="xs:decimal">1</Password>
@@ -2283,7 +2283,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">14</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">7</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -2356,7 +2356,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">15</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">16</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">1</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -2401,7 +2401,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">16</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">13</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -2559,7 +2559,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">17</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">16</TransactionType>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
         <Password xmlns="" xsi:type="xs:decimal">1</Password>
@@ -2609,7 +2609,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">18</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">8</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>
@@ -2708,7 +2708,7 @@
       <TransactionRecord00 xmlns="http://www.ibm.com/dfdl/Tlog/SA">
         <TerminalNumber xmlns="" xsi:type="xs:hexBinary">0001</TerminalNumber>
         <TransactionNumber xmlns="" xsi:type="xs:int">19</TransactionNumber>
-        <DateTime xmlns="" xsi:type="xs:int">1010151417</DateTime>
+        <DateTime xmlns="" xsi:type="xs:long">1010151417</DateTime>
         <TransactionType xmlns="" xsi:type="xs:hexBinary">17</TransactionType>
         <NumberOfStrings xmlns="" xsi:type="xs:decimal">17</NumberOfStrings>
         <Operator xmlns="" xsi:type="xs:decimal">1</Operator>

--- a/src/test/resources/com/toshibacommerce/tlog/ace_00_01.xml
+++ b/src/test/resources/com/toshibacommerce/tlog/ace_00_01.xml
@@ -5,7 +5,7 @@
       <TransactionRecord00>
         <TerminalNumber xsi:type="xs:hexBinary">0632</TerminalNumber>
         <TransactionNumber xsi:type="xs:int">2</TransactionNumber>
-        <DateTime xsi:type="xs:int">1120191336</DateTime>
+        <DateTime xsi:type="xs:long">1120191336</DateTime>
         <TransactionType xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xsi:type="xs:decimal">16</NumberOfStrings>
         <Operator xsi:type="xs:decimal">1</Operator>
@@ -37,7 +37,7 @@
         <Indicat4>
           <Bits_0_31 xsi:type="xs:decimal">0</Bits_0_31>
         </Indicat4>
-        <OrdinalNumber xsi:type="xs:int">4</OrdinalNumber>
+        <OrdinalNumber xsi:type="xs:decimal">4</OrdinalNumber>
       </TransactionRecord01>
     </TransactionRecord>
   </Transaction>

--- a/src/test/resources/com/toshibacommerce/tlog/ace_02_03_07.xml
+++ b/src/test/resources/com/toshibacommerce/tlog/ace_02_03_07.xml
@@ -5,7 +5,7 @@
       <TransactionRecord00>
         <TerminalNumber xsi:type="xs:hexBinary">0706</TerminalNumber>
         <TransactionNumber xsi:type="xs:int">158</TransactionNumber>
-        <DateTime xsi:type="xs:int">910141725</DateTime>
+        <DateTime xsi:type="xs:long">910141725</DateTime>
         <TransactionType xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xsi:type="xs:decimal">32</NumberOfStrings>
         <Operator xsi:type="xs:decimal">706</Operator>

--- a/src/test/resources/com/toshibacommerce/tlog/ace_05_97-05.xml
+++ b/src/test/resources/com/toshibacommerce/tlog/ace_05_97-05.xml
@@ -5,7 +5,7 @@
       <TransactionRecord00>
         <TerminalNumber xsi:type="xs:hexBinary">0706</TerminalNumber>
         <TransactionNumber xsi:type="xs:int">179</TransactionNumber>
-        <DateTime xsi:type="xs:int">910151534</DateTime>
+        <DateTime xsi:type="xs:long">910151534</DateTime>
         <TransactionType xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xsi:type="xs:decimal">8</NumberOfStrings>
         <Operator xsi:type="xs:decimal">706</Operator>

--- a/src/test/resources/com/toshibacommerce/tlog/ace_80-01_98_13_97-13.xml
+++ b/src/test/resources/com/toshibacommerce/tlog/ace_80-01_98_13_97-13.xml
@@ -5,7 +5,7 @@
       <TransactionRecord00>
         <TerminalNumber xsi:type="xs:hexBinary">0680</TerminalNumber>
         <TransactionNumber xsi:type="xs:int">2</TransactionNumber>
-        <DateTime xsi:type="xs:int">1107191336</DateTime>
+        <DateTime xsi:type="xs:long">1107191336</DateTime>
         <TransactionType xsi:type="xs:hexBinary">00</TransactionType>
         <NumberOfStrings xsi:type="xs:decimal">16</NumberOfStrings>
         <Operator xsi:type="xs:decimal">1</Operator>


### PR DESCRIPTION
- change `DateTime` type from `xs:int` to `xs:long` and OrdinalNumber from `xs:int` to `xs:decimal` per the change in 9b64a74bf1f3da3159506aaede0d22da281aa6be